### PR TITLE
Fix Talkback accessibility: remove contentDescription from spinners and result TextView

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,7 +25,6 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="4dp"
             android:layout_weight="1"
-            android:contentDescription="@string/select_model"/>
     </LinearLayout>
     <LinearLayout
         android:id="@+id/layout_language"
@@ -47,7 +46,6 @@
             android:layout_height="wrap_content"
             android:layout_marginEnd="4dp"
             android:layout_weight="1"
-            android:contentDescription="@string/language"/>
     </LinearLayout>
     <LinearLayout
         android:layout_width="match_parent"
@@ -187,7 +185,6 @@
                 android:id="@+id/tvResult"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:contentDescription="@string/model_output"
                 android:text = "@string/instructions"
                 android:textSize="16sp" />
         </ScrollView>


### PR DESCRIPTION
**Bug:** Talkback reads static descriptions instead of dynamic values for three UI elements:

- **Model spinner** (`spnrTfliteFiles`): read "Select Model" instead of the selected model filename
- **Language spinner** (`spnrLanguage`): read "Language" instead of the selected language (e.g., "English")  
- **Result text view** (`tvResult`): read "Model output" instead of the actual transcribed text

**Fix:** Removed `android:contentDescription` from these three elements. Their purpose is clear from adjacent label TextViews. Without contentDescription, Talkback reads the actual dynamic values.

**Preserved:** All `contentDescription` attributes on static icon-only elements remain intact (`btnRecord`, `btnInfo`, `fabCopy`, `mode_append`, `mode_translate`, `mode_tts`, `mode_simple_chinese`).

Reported by a blind user who confirmed the fix works on their device.